### PR TITLE
sdm660-common: Enable adoptable storage

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -9,14 +9,14 @@
 #<src>                                   <mnt_point>        <type> <mnt_flags and options>                          <fs_mgr_flags>
 /dev/block/bootdevice/by-name/system     /                  ext4   ro,barrier=1,discard                             wait,slotselect,verify
 /dev/block/bootdevice/by-name/userdata   /data              ext4   noatime,nosuid,nodev,barrier=1,noauto_da_alloc,discard,lazytime,errors=panic   wait,check,latemount,formattable,fileencryption=ice,quota,reservedsize=128M
-/devices/soc/c084000.sdhci/mmc_host*     /storage/sdcard1   vfat   nosuid,nodev                                     wait,voldmanaged=sdcard1:auto
 /dev/block/bootdevice/by-name/misc       /misc              emmc   defaults                                         defaults
 /dev/block/bootdevice/by-name/modem      /vendor/firmware_mnt  vfat   ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/bluetooth  /vendor/bt_firmware   vfat   ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait,slotselect
 /dev/block/bootdevice/by-name/dsp        /vendor/dsp           ext4   ro,nosuid,nodev,barrier=1                        wait,slotselect
 /dev/block/bootdevice/by-name/persist    /mnt/vendor/persist   ext4   noatime,nosuid,nodev,barrier=1                   wait
 
-#usb otg auto mount, 80-NF283-1_D, page 200, mount point: /mnt/media_rw/
+# Removeable
+/devices/soc/c084000.sdhci/mmc_host*     auto               auto   defaults                                         wait,voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/*/xhci-hcd.0.auto*              auto               auto   defaults                                         voldmanaged=usb:auto
 
 # ZRAM


### PR DESCRIPTION
- Also move the entry to bottom and change mnt_point, mnt_flags and type

Change-Id: I4fdb6ccca9327289b7fb8a4ba17d8c0df5f951a3